### PR TITLE
Add Ћ to replace th

### DIFF
--- a/Resolver.php
+++ b/Resolver.php
@@ -133,6 +133,8 @@ class Resolver
 		'OE' => 'Œ',
 		'OO' => 'Ꝏ',
 		'oo' => 'ꝏ',
+		'Th' => 'Ћ',
+		'th' => 'ћ',
 		'ft' => 'ﬅ',
 		'ue' => 'ᵫ' //weird looking in twitter
 	];


### PR DESCRIPTION
`Ћ` ([the Cryillic letter "Tshe"](https://en.wikipedia.org/wiki/Tshe)) looks very similar to `th`, the most common digraph in English. So by using `Ћ` (and it's lowercase variant, `ћ`) you could probably save tons in a common Tweet more than as it is right now without it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mightypork/twitmin/3)
<!-- Reviewable:end -->
